### PR TITLE
no linebreaks in url scheme

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,13 +53,9 @@ version="0.7.0">
       <config-file target="*-Info.plist" parent="CFBundleURLTypes">
         <array>
           <dict>
-            <key>
-              CFBundleURLSchemes
-            </key>
+            <key>CFBundleURLSchemes</key>
             <array>
-              <string>
-                $URL_SCHEME
-              </string>
+              <string>$URL_SCHEME</string>
             </array>
           </dict>
         </array>


### PR DESCRIPTION
Bugfix, the added value for the url scheme in the .plist now do not containt linebreaks anymore.
